### PR TITLE
fix back to gallary link in image detail view

### DIFF
--- a/src/pages/ViewImage/ViewImage.jsx
+++ b/src/pages/ViewImage/ViewImage.jsx
@@ -48,7 +48,7 @@ class ViewImage extends Component {
                         </>
                         }
                         <br></br>
-                <Link to="/gallery">
+                <Link to={`/gallery/${image.user}`}>
                     Back to Gallery
                 </Link><br />
                 </div>


### PR DESCRIPTION
Fixed issue where old "back to gallery" link lead to an old, unuseful page.